### PR TITLE
Fix eval labels path

### DIFF
--- a/PaddleOCR-main/configs/rec/my_rec_train.yml
+++ b/PaddleOCR-main/configs/rec/my_rec_train.yml
@@ -81,7 +81,7 @@ Eval:
   dataset:
     name: SimpleDataSet
     data_dir: ./My data
-    label_file_list: ["./My data/val_labels.txt"]
+    label_file_list: ["./My data/eval_labels.txt"]
     transforms:
       - DecodeImage: # load image
           img_mode: BGR

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ python3 tools/train.py -c configs/rec/my_rec_train.yml
 ```
 
 The config expects images referenced in `train_labels.txt` to be relative to the
-`My data` directory.
+`My data` directory. For evaluation, it uses `eval_labels.txt` from the same
+directory as the validation split.


### PR DESCRIPTION
## Summary
- set `my_rec_train.yml` to use `eval_labels.txt`
- document evaluation split in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_683d8cefc2d883329ff703727e4c5038