### PR TITLE
Update data paths in training config

### DIFF
--- a/PaddleOCR-main/configs/rec/my_rec_train.yml
+++ b/PaddleOCR-main/configs/rec/my_rec_train.yml
@@ -14,7 +14,7 @@ Global:
   save_inference_dir: ./
   use_visualdl: False
   infer_img: doc/imgs_words/ch/word_1.jpg
-  character_dict_path: ./My data/dict.txt
+  character_dict_path: ../My data/dict.txt
   max_text_length: &max_text_length 25
   infer_mode: False
   use_space_char: True
@@ -74,8 +74,8 @@ Metric:
 Train:
   dataset:
     name: SimpleDataSet
-    data_dir: ./My data
-    label_file_list: ["./My data/train_labels.txt"]
+    data_dir: ../My data
+    label_file_list: ["../My data/train_labels.txt"]
     transforms:
       - DecodeImage:
           img_mode: BGR
@@ -95,8 +95,8 @@ Train:
 Eval:
   dataset:
     name: SimpleDataSet
-    data_dir: ./My data
-    label_file_list: ["./My data/eval_labels.txt"]
+    data_dir: ../My data
+    label_file_list: ["../My data/eval_labels.txt"]
     transforms:
       - DecodeImage:
           img_mode: BGR


### PR DESCRIPTION
## Summary
- fix dataset paths in `my_rec_train.yml` so they look one level above the repo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_683daf0647dc8332861fe5cdfce42cf3