### PR TITLE
Fix Unicode normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ in the same directory:
 - `train_labels.txt` – each line has `image_path\tlabel`
 - `dict.txt` – one unique character per line
 
+The script also normalizes all filenames and CSV entries to Unicode NFC form so
+that paths in `train_labels.txt` match the actual files on disk.
+
 ## Training
 
 A training configuration is provided at

--- a/prepare_paddleocr_data.py
+++ b/prepare_paddleocr_data.py
@@ -1,10 +1,19 @@
 import csv
+import unicodedata
 from pathlib import Path
 
 # Paths
 csv_path = Path('My data/PL-20k-hand-labelled_labels.csv')
 label_txt_path = Path('My data/train_labels.txt')
 dict_path = Path('My data/dict.txt')
+
+# Ensure filenames on disk use a consistent normalization form (NFC)
+for p in csv_path.parent.iterdir():
+    if not p.is_file():
+        continue
+    norm_name = unicodedata.normalize('NFC', p.name)
+    if norm_name != p.name:
+        p.rename(p.with_name(norm_name))
 
 unique_chars = set()
 
@@ -16,7 +25,7 @@ with csv_path.open(newline='', encoding='utf-8') as csvfile, \
             continue
         if len(row) < 2:
             continue
-        img_path = row[0].strip()
+        img_path = unicodedata.normalize('NFC', row[0].strip())
         label = row[1].strip()
         outfile.write(f"{img_path}\t{label}\n")
         for ch in label:


### PR DESCRIPTION
## Summary
- normalize filenames in dataset scripts
- explain filename normalization in README

## Testing
- `python3 -m py_compile prepare_paddleocr_data.py`

------
https://chatgpt.com/codex/tasks/task_e_683df8d765cc8332bf1e2f724cb7e568