### PR TITLE
Fix filename normalization during dataset extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This repository contains a minimal example showing how to train a PaddleOCR
 recognition model on a custom dataset stored under `My data/`.
 
+Run `download_pl20k.py` to download the sample dataset and normalize all
+filenames to UTF-8 so they match the accompanying CSV labels:
+
+```bash
+python3 download_pl20k.py
+```
+
+The script extracts `PL-20k-hand-labelled.tar.gz` and converts any decomposed
+Unicode sequences in file paths to their canonical NFC form.
+
 ## Preparing the Dataset
 
 Run `prepare_paddleocr_data.py` to convert the CSV labels into the format

--- a/download_pl20k.py
+++ b/download_pl20k.py
@@ -28,6 +28,12 @@ def extract_tar(tar_path: Path, out_dir: Path):
     with tarfile.open(tar_path, mode='r:gz', encoding='utf-8', errors='surrogateescape') as tar:
         tar.extractall(path=out_dir)
 
+    # Normalize extracted filenames to NFC so that they match CSV entries
+    for path in sorted(out_dir.rglob('*'), key=lambda p: len(str(p)), reverse=True):
+        new_name = unicodedata.normalize('NFC', path.name)
+        if new_name != path.name:
+            path.rename(path.with_name(new_name))
+
 # Simple encoding detection for the CSV
 
 def read_csv_guess(path: Path):


### PR DESCRIPTION
## Summary
- normalize extracted filenames to NFC in `download_pl20k.py`
- document dataset download and normalization in README

## Testing
- `python3 -m py_compile download_pl20k.py`

------
https://chatgpt.com/codex/tasks/task_e_683f222981a4833285377428402cc111