### PR TITLE
Fix dataset extraction path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ filenames to UTF-8 so they match the accompanying CSV labels:
 python3 download_pl20k.py
 ```
 
-The script extracts `PL-20k-hand-labelled.tar.gz` and converts any decomposed
+The script extracts `PL-20k-hand-labelled.tar.gz` into the `My data/` directory
+(creating the `PL-20k-hand-labelled/` folder) and converts any decomposed
 Unicode sequences in file paths to their canonical NFC form.
 
 ## Preparing the Dataset

--- a/download_pl20k.py
+++ b/download_pl20k.py
@@ -77,16 +77,19 @@ def verify_files(csv_path: Path, data_dir: Path):
 def main():
     tar_path = DATA_DIR / 'PL-20k-hand-labelled.tar.gz'
     csv_path = DATA_DIR / 'PL-20k-hand-labelled_labels.csv'
-    extract_dir = DATA_DIR / 'PL-20k-hand-labelled'
+    # Extract the tarball directly under DATA_DIR. The archive itself already
+    # contains the top-level ``PL-20k-hand-labelled`` directory, so extracting
+    # into DATA_DIR avoids creating an extra nested folder.
+    extract_root = DATA_DIR
 
     download(TAR_URL, tar_path)
     download(CSV_URL, csv_path)
 
     inspect_tar_names(tar_path)
-    extract_tar(tar_path, extract_dir)
+    extract_tar(tar_path, extract_root)
 
     ensure_csv_utf8(csv_path)
-    verify_files(csv_path, extract_dir)
+    verify_files(csv_path, extract_root / 'PL-20k-hand-labelled')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- avoid double nesting when extracting `PL-20k-hand-labelled.tar.gz`
- document where the folder ends up

## Testing
- `python3 -m py_compile download_pl20k.py`


------
https://chatgpt.com/codex/tasks/task_e_683f24057e8c8332bf12e4ebc9ec38cb